### PR TITLE
fix: fixed iOS behavior Problem

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,10 +25,10 @@
     "ios"
   ],
   "author": "Keisuke Takagi",
-  "homepage": "",
+  "homepage": "https://github.com/takagimeow/react-native-simple-sticky-header#readme",
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "https://github.com/takagimeow/react-native-simple-sticky-header"
   },
   "license": "MIT",
   "lint-staged": {


### PR DESCRIPTION
I Fixed an issue where the iOS version did not behave as expected.

今回、scrollYを必ず0以上に保証するclampedScrollYという変数を用意することで、勢いよく上にスクロールした際にヘッダーが隠れてしまう問題を修正することができました。